### PR TITLE
Update rubocop yaml to ignore http(s) links in LineLength cop

### DIFF
--- a/lib/much-style-guide/rubocop.yml
+++ b/lib/much-style-guide/rubocop.yml
@@ -30,6 +30,8 @@ Layout/LineLength:
     - !ruby/regexp /\A\s*module {?\w+(?:::\w+)+}?\z/
     - !ruby/regexp /\A\s*class {?\w+(?:::\w+)+}?\z/
     - !ruby/regexp /\A\s*include {?\w+(?:::\w+)+}?\z/
+    # Links
+    - !ruby/regexp /\A\s*#\s*http.*\z/
 
 Layout/MultilineArrayBraceLayout:
   EnforcedStyle: new_line


### PR DESCRIPTION
This updates Rubocop's `Layout/LineLength` cop in our `rubocop.yml`
to ignore lines with http(s) links.
