### PR TITLE
exclude long require lines

### DIFF
--- a/lib/much-style-guide/rubocop.yml
+++ b/lib/much-style-guide/rubocop.yml
@@ -39,6 +39,8 @@ Layout/LineLength:
     - !ruby/regexp /\A\s*include {?\w+(?:::\w+)+}?\z/
     # Links
     - !ruby/regexp /\A\s*#\s*http.*\z/
+    # Requires
+    - !ruby/regexp /\A\s*require\s+".+\z/
 
 Layout/MultilineArrayBraceLayout:
   EnforcedStyle: new_line


### PR DESCRIPTION
You don't always have control over how long a require is b/c
you don't control the naming/namespacing of objects. Also sometimes
it is desirable to use long/deeply-nested names.
