### PR TITLE
disable Style/TrivialAccessors

### DIFF
--- a/lib/much-style-guide/rubocop.yml
+++ b/lib/much-style-guide/rubocop.yml
@@ -198,5 +198,8 @@ Style/TrailingCommaInArrayLiteral:
 Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: consistent_comma
 
+Style/TrivialAccessors:
+  Enabled: false
+
 Style/WordArray:
   Enabled: false


### PR DESCRIPTION
This is too pedantic for our taste. Also there are times where
we want to e.g. manually define a trivial reader to make that
reader private.
