### PR TITLE
add preferred collection methods to Rubocop configuration

### DIFF
--- a/lib/much-style-guide/rubocop.yml
+++ b/lib/much-style-guide/rubocop.yml
@@ -137,6 +137,15 @@ Style/CommandLiteral:
   EnforcedStyle: backticks
   AllowInnerBackticks: true
 
+Style/CollectionMethods:
+  PreferredMethods:
+    collect: map
+    collect!: map!
+    inject: reduce
+    detect: find
+    find_all: select
+    member?: include
+
 Style/Documentation:
   Enabled: false
 


### PR DESCRIPTION
This allows Rubocop to nudge about our preferences.

@jcredding @nweathersbee extracting from our big app usage, FYI.