### PR TITLE
add Layout/MultilineAssignmentLayout `new_line`

### DIFF
--- a/lib/much-style-guide/rubocop.yml
+++ b/lib/much-style-guide/rubocop.yml
@@ -45,6 +45,9 @@ Layout/LineLength:
 Layout/MultilineArrayBraceLayout:
   EnforcedStyle: new_line
 
+Layout/MultilineAssignmentLayout:
+  EnforcedStyle: new_line
+
 Layout/MultilineHashBraceLayout:
   EnforcedStyle: new_line
 


### PR DESCRIPTION
This enforces wrapping multiline assignments with a newline to
the right of the assignment operator.
